### PR TITLE
Incorrect escaping of quotes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,18 +21,18 @@ Available states
 Installs and configures the letsencrypt cli from git, creates the requested certificates and installs renewal cron job.
 This is a shortcut for letsencrypt.install letsencrypt.config and letsencrypt.domains .
 
-``install``
+``letsencrypt.install``
 -----------
 
 Only installs the letsencrypt client. Currently the letsencrypt-auto method is used. This will create a virtualenv in the /root/.config/ directory.
 The installation method will be replaced by using packages, as default as soon as they ara stable and available for all major platforms.
 
-``config``
+``letsencrypt.config``
 ----------
 
 Manages /etc/letsencrypt/cli.ini config file.
 
-``domains``
+``letsencrypt.domains``
 -----------
 Creates a certificate with the domains in each domain set (letsencrypt:domainsets in pillar). Letsencrypt uses a relatively short validity of 90 days.
 Therefore, a cron job for automatic renewal every 60 days is installed for each domain set as well.

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -47,6 +47,8 @@ create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
       - file: letsencrypt-config
       - file: /usr/local/bin/check_letsencrypt_cert.sh
 
+# domainlist[0] represents the "CommonName", and the rest
+# represent SubjectAlternativeNames
 letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
   cron.present:
     - name: /usr/local/bin/renew_letsencrypt_cert.sh {{ domainlist|join(' ') }}
@@ -59,19 +61,15 @@ letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
       - file: /usr/local/bin/renew_letsencrypt_cert.sh
 
-{% for domain in domainlist %}
-
-create-fullchain-privkey-pem-for-{{ domain }}:
+create-fullchain-privkey-pem-for-{{ domainlist[0] }}:
   cmd.run:
     - name: |
-        cat /etc/letsencrypt/live/{{ domain }}/fullchain.pem \
-            /etc/letsencrypt/live/{{ domain }}/privkey.pem \
-            > /etc/letsencrypt/live/{{ domain }}/fullchain-privkey.pem && \
-        chmod 600 /etc/letsencrypt/live/{{ domain }}/fullchain-privkey.pem
-    - creates: /etc/letsencrypt/live/{{ domain }}/fullchain-privkey.pem
+        cat /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain.pem \
+            /etc/letsencrypt/live/{{ domainlist[0] }}/privkey.pem \
+            > /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem && \
+        chmod 600 /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem
+    - creates: /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem
     - require:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
-
-{% endfor %}
 
 {% endfor %}

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -24,20 +24,9 @@
 
 /usr/local/bin/renew_letsencrypt_cert.sh:
   file.managed:
+    - template: jinja
+    - source: salt://letsencrypt/files/renew_letsencrypt_cert.sh.jinja
     - mode: 755
-    - contents: |
-        #!/bin/bash
-        for DOMAIN in "$@"
-        do
-            if ! /usr/local/bin/check_letsencrypt_cert.sh "$DOMAIN" > /dev/null
-            then
-                {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d "$DOMAIN" certonly || exit 1
-                cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem \
-                    /etc/letsencrypt/live/${DOMAIN}/privkey.pem \
-                    > /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-                chmod 600 /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-            fi
-        done
     - require:
       - file: /usr/local/bin/check_letsencrypt_cert.sh
 

--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -10,7 +10,7 @@ done
 
 if ! /usr/local/bin/check_letsencrypt_cert.sh "$@" > /dev/null
 then
-    {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly "$JOINED" || exit 1
+    {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly $JOINED || exit 1
     cat /etc/letsencrypt/live/${COMMON_NAME}/fullchain.pem \
         /etc/letsencrypt/live/${COMMON_NAME}/privkey.pem \
         > /etc/letsencrypt/live/${COMMON_NAME}/fullchain-privkey.pem || exit 1

--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -1,13 +1,18 @@
 #!/bin/bash
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
+COMMON_NAME="$1"
+
+JOINED=""
 for DOMAIN in "$@"
 do
-    if ! /usr/local/bin/check_letsencrypt_cert.sh "$DOMAIN" > /dev/null
-    then
-        {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d "$DOMAIN" certonly || exit 1
-        cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem \
-            /etc/letsencrypt/live/${DOMAIN}/privkey.pem \
-            > /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-        chmod 600 /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-    fi
+    JOINED+=" -d $DOMAIN"
 done
+
+if ! /usr/local/bin/check_letsencrypt_cert.sh "$@" > /dev/null
+then
+    {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly "$JOINED" || exit 1
+    cat /etc/letsencrypt/live/${COMMON_NAME}/fullchain.pem \
+        /etc/letsencrypt/live/${COMMON_NAME}/privkey.pem \
+        > /etc/letsencrypt/live/${COMMON_NAME}/fullchain-privkey.pem || exit 1
+    chmod 600 /etc/letsencrypt/live/${COMMON_NAME}/fullchain-privkey.pem || exit 1
+fi

--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -1,0 +1,13 @@
+#!/bin/bash
+{% from "letsencrypt/map.jinja" import letsencrypt with context %}
+for DOMAIN in "$@"
+do
+    if ! /usr/local/bin/check_letsencrypt_cert.sh "$DOMAIN" > /dev/null
+    then
+        {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d "$DOMAIN" certonly || exit 1
+        cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem \
+            /etc/letsencrypt/live/${DOMAIN}/privkey.pem \
+            > /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
+        chmod 600 /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
+    fi
+done


### PR DESCRIPTION
crontab update script does not properly handle arguments, passing them with single quotes

error:

> letsencrypt: error: unrecognized arguments:  -d mydomain.ru

```
/renew_letsencrypt_cert.sh mydomain.ru
+ COMMON_NAME=linkexplorer.ru
+ JOINED=
+ for DOMAIN in '"$@"'
+ JOINED+=' -d linkexplorer.ru'
+ /usr/local/bin/check_letsencrypt_cert.sh mydomain.ru
+ /opt/letsencrypt/letsencrypt-auto certonly ' -d mydomain.ru'
usage: 
  letsencrypt-auto [SUBCOMMAND] [options] [-d domain] [-d domain] ...

Certbot can obtain and install HTTPS/TLS/SSL certificates.  By default,
it will attempt to use a webserver both for obtaining and installing the
cert. Major SUBCOMMANDS are:

  (default) run        Obtain & install a cert in your current webserver
  certonly             Obtain cert, but do not install it (aka "auth")
  install              Install a previously obtained cert in a server
  renew                Renew previously obtained certs that are near expiry
  revoke               Revoke a previously obtained certificate
  register             Perform tasks related to registering with the CA
  rollback             Rollback server configuration changes made during install
  config_changes       Show changes made to server config during installation
  plugins              Display information about installed plugins
letsencrypt: error: unrecognized arguments:  -d mydomain.ru
+ exit 1
```
